### PR TITLE
feat: kako 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,11 +28,23 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	//valid
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	// WebSocket
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+	//Webflux
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// login
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+	implementation 'org.springframework.boot:spring-boot-starter-mail' //이메일 인증
 
 }
 

--- a/src/main/java/org/sspoid/sspoid/api/controller/auth/KakaoLoginController.java
+++ b/src/main/java/org/sspoid/sspoid/api/controller/auth/KakaoLoginController.java
@@ -1,0 +1,28 @@
+package org.sspoid.sspoid.api.controller.auth;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.sspoid.sspoid.api.dto.KakaoUserInfoResponse;
+import org.sspoid.sspoid.api.service.KakaoLoginService;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class KakaoLoginController {
+
+    private final KakaoLoginService kakaoLoginService;
+
+    @GetMapping("/api/login/kakao")
+    public ResponseEntity<?> callback(@RequestParam("code") String code) {
+        String accessToken = kakaoLoginService.getAccessToken(code);
+        KakaoUserInfoResponse userInfo = kakaoLoginService.getUserInfo(accessToken);
+
+        return ResponseEntity.ok(userInfo);
+    }
+
+}

--- a/src/main/java/org/sspoid/sspoid/api/dto/KakaoUserInfoResponse.java
+++ b/src/main/java/org/sspoid/sspoid/api/dto/KakaoUserInfoResponse.java
@@ -1,0 +1,44 @@
+package org.sspoid.sspoid.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.context.annotation.Profile;
+
+import java.util.HashMap;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoUserInfoResponse {
+
+    @JsonProperty("id")
+    private Long id;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @JsonProperty("properties")
+    private HashMap<String, String> properties;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class KakaoAccount {
+
+        @JsonProperty("email")
+        private String email;
+
+        @JsonProperty("profile")
+        private Profile profile;
+
+        @Getter
+        @NoArgsConstructor
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class Profile {
+            @JsonProperty("nickname")
+            private String nickname;
+        }
+    }
+}

--- a/src/main/java/org/sspoid/sspoid/api/dto/KakoTokenResponse.java
+++ b/src/main/java/org/sspoid/sspoid/api/dto/KakoTokenResponse.java
@@ -1,0 +1,24 @@
+package org.sspoid.sspoid.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakoTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+
+    @JsonProperty("scope")
+    private String scope;
+}

--- a/src/main/java/org/sspoid/sspoid/api/service/KakaoLoginService.java
+++ b/src/main/java/org/sspoid/sspoid/api/service/KakaoLoginService.java
@@ -1,0 +1,60 @@
+package org.sspoid.sspoid.api.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.sspoid.sspoid.api.dto.KakaoUserInfoResponse;
+import org.sspoid.sspoid.api.dto.KakoTokenResponse;
+import org.sspoid.sspoid.common.config.KakaoConfig;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoLoginService {
+
+    private final KakaoConfig kakaoConfig;
+
+    public String getAccessToken(String code) {
+        log.info("🔑 인가 코드: {}", code);
+        log.info("🔧 client_id: {}", kakaoConfig.getClientId());
+        log.info("🔧 redirect_uri: {}", kakaoConfig.getRedirectUri());
+
+        KakoTokenResponse response = WebClient.create(kakaoConfig.getTokenUrl())
+                .post()
+                .uri(uriBuilder -> uriBuilder.path("/oauth/token")
+                        .queryParam("grant_type", "authorization_code")
+                        .queryParam("client_id", kakaoConfig.getClientId())
+                        .queryParam("redirect_uri", kakaoConfig.getRedirectUri())
+                        .queryParam("code", code)
+                        .build()
+                )
+                .header(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, r -> {
+                    log.error("❌ 토큰 요청 실패 상태 코드: {}", r.statusCode());
+                    return Mono.error(new RuntimeException("토큰 발급 실패"));
+                })
+                .bodyToMono(KakoTokenResponse.class)
+                .block();
+
+        log.info("엑세스 토큰 수신됨: {}", response.getAccessToken());  // ✅ 토큰 확인
+
+        return response.getAccessToken();
+    }
+
+    public KakaoUserInfoResponse getUserInfo(String accessToken) {
+        return WebClient.create(kakaoConfig.getUserInfoUrl())
+                .get()
+                .uri("/v2/user/me")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .header(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, r -> Mono.error(new RuntimeException("사용자 정보 조회 실패")))
+                .bodyToMono(KakaoUserInfoResponse.class)
+                .block();
+    }
+}

--- a/src/main/java/org/sspoid/sspoid/common/config/KakaoConfig.java
+++ b/src/main/java/org/sspoid/sspoid/common/config/KakaoConfig.java
@@ -1,0 +1,24 @@
+package org.sspoid.sspoid.common.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Configuration
+public class KakaoConfig {
+
+    @Value("${kakao.api-key}")
+    private String clientId;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    public String getTokenUrl(){
+        return "https://kauth.kakao.com";
+    }
+    public String getUserInfoUrl(){
+        return "https://kapi.kakao.com";
+    }
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:mysql://127.0.0.1:3306/sspoid_db?useSSL=false&serverTimezone=Asia/Seoul
+    url: jdbc:mysql://127.0.0.1:3306/sspoid_db?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
     username: root
     password: 12345678
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,7 @@ server:
 spring:
   profiles:
     active: prod
+
+kakao:
+  api-key: ${API_KEY} # 암호화 필요
+  redirect-uri: http://localhost:8080/api/login/kakao


### PR DESCRIPTION
<!--
[제목]
작업: 회원 가입 기능 구현
-->
## 🔗 관련 이슈
<!--
ex) - #12  
-->
- #7 

## 📌 작업 내용
카카오 소셜 로그인 연동을 위해 OAuth 2.0 Authorization Code Grant 방식을 적용하였고, 사용자 인증 후 **인가 코드(code)**를 받아 이를 통해 **액세스 토큰(access token)**과 사용자 정보를 조회하는 기능을 구현했습니다.

### ⚙️ 구현 내용 요약
- /login/kakao?code=... 으로 전달된 인가 코드를 이용하여 토큰 요청

- 카카오 API로부터 access_token 수신

- 해당 토큰을 사용하여 사용자 정보 조회 (이메일, 닉네임 등)

- 응답 JSON을 파싱하여 로그 출력 (DB 저장은 다음 단계에서 구현 예정)

### 🔄 카카오 로그인 연동 흐름
사용자 카카오 로그인 → 인가 코드 발급

- 인가 코드 → access token 요청 (POST /oauth/token)

- access token → 사용자 정보 조회 (GET /v2/user/me)

### 🔑 주요 용어 정리
**인가 코드 (authorization_code)**

- 사용자가 카카오 로그인에 성공했을 때 카카오가 redirect_uri에 붙여 보내주는 인증용 코드

**액세스 토큰 (access_token)**

- 인가 코드를 통해 받아오는 실제 API 호출용 토큰

**WebClient**

- 비동기 HTTP 요청을 보내기 위한 Spring WebFlux의 클라이언트 라이브러리

**Bearer 토큰**

- HTTP Authorization 헤더에 사용되는 토큰 형식. Bearer [토큰] 형태여야 함 (Bearer 뒤 공백 주의!)

### 🤯 추후 해야할 일
- 응답받은 사용자 정보를 DB(User 테이블)에 저장


## 📚 참고 자료
https://suyeoniii.tistory.com/79

<!--  
- https://example.com/signup-api (회원 가입 API 설계서)  
- https://example.com/bcrypt (Spring Security BCryptPasswordEncoder 사용법)
-->  

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
