### PR TITLE
feat: 자체 로그인 및 회원정보 db 저장

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 23-feat-자체-로그인-및-회원정보-db-저장
 
 jobs:
   build-and-deploy:
@@ -67,4 +68,6 @@ jobs:
               -DRDS_HOST='${{ secrets.RDS_HOST }}' \
               -DRDS_USERNAME='${{ secrets.RDS_USERNAME }}' \
               -DRDS_PASSWORD='${{ secrets.RDS_PASSWORD }}' \
+              -DAPI_KEY='${{ secrets.API_KEY }}' \
+
               /home/ec2-user/sspoid/build/libs/sspoid-0.0.1-SNAPSHOT.jar > /home/ec2-user/application.log 2>&1 &

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,4 +70,4 @@ jobs:
               -DRDS_PASSWORD='${{ secrets.RDS_PASSWORD }}' \
               -DAPI_KEY='${{ secrets.API_KEY }}' \
 
-              /home/ec2-user/sspoid/build/libs/sspoid-0.0.1-SNAPSHOT.jar > /home/ec2-user/application.log 2>&1 &
+              /home/ec2-user/sspoid/sspoid-0.0.1-SNAPSHOT.jar > /home/ec2-user/application.log 2>&1 &

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build project
-        run: ./gradlew build
+        run: ./gradlew build -x test
 
       - name: Deploy JAR to EC2
         uses: appleboy/scp-action@v0.1.7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,5 +69,4 @@ jobs:
               -DRDS_USERNAME='${{ secrets.RDS_USERNAME }}' \
               -DRDS_PASSWORD='${{ secrets.RDS_PASSWORD }}' \
               -DAPI_KEY='${{ secrets.API_KEY }}' \
-
               /home/ec2-user/sspoid/build/libs/sspoid-0.0.1-SNAPSHOT.jar > /home/ec2-user/application.log 2>&1 &

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,4 +70,4 @@ jobs:
               -DRDS_PASSWORD='${{ secrets.RDS_PASSWORD }}' \
               -DAPI_KEY='${{ secrets.API_KEY }}' \
 
-              /home/ec2-user/sspoid/sspoid-0.0.1-SNAPSHOT.jar > /home/ec2-user/application.log 2>&1 &
+              /home/ec2-user/sspoid/build/libs/sspoid-0.0.1-SNAPSHOT.jar > /home/ec2-user/application.log 2>&1 &

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,8 +65,11 @@ jobs:
             fi
 
             nohup java -jar \
+              -DPASSWORD='${{ secrets.PASSWORD }}' \
               -DRDS_HOST='${{ secrets.RDS_HOST }}' \
               -DRDS_USERNAME='${{ secrets.RDS_USERNAME }}' \
               -DRDS_PASSWORD='${{ secrets.RDS_PASSWORD }}' \
               -DAPI_KEY='${{ secrets.API_KEY }}' \
+              -DJWT_SECRET='${{ secrets.JWT_SECRET }}' \
+              -
               /home/ec2-user/sspoid/build/libs/sspoid-0.0.1-SNAPSHOT.jar > /home/ec2-user/application.log 2>&1 &

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,5 +71,4 @@ jobs:
               -DRDS_PASSWORD='${{ secrets.RDS_PASSWORD }}' \
               -DAPI_KEY='${{ secrets.API_KEY }}' \
               -DJWT_SECRET='${{ secrets.JWT_SECRET }}' \
-              -
               /home/ec2-user/sspoid/build/libs/sspoid-0.0.1-SNAPSHOT.jar > /home/ec2-user/application.log 2>&1 &

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 	implementation 'org.springframework.boot:spring-boot-starter-mail' //이메일 인증
 
+	// security - BCrypt
+	implementation 'org.springframework.security:spring-security-crypto'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/sspoid/sspoid/api/controller/auth/AuthController.java
+++ b/src/main/java/org/sspoid/sspoid/api/controller/auth/AuthController.java
@@ -1,0 +1,72 @@
+package org.sspoid.sspoid.api.controller.auth;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.sspoid.sspoid.api.dto.auth.EmailSendRequest;
+import org.sspoid.sspoid.api.dto.auth.EmailVerifyRequest;
+import org.sspoid.sspoid.api.dto.auth.LoginRequest;
+import org.sspoid.sspoid.api.dto.auth.SignUpRequest;
+import org.sspoid.sspoid.api.dto.auth.TokenResponse;
+import org.sspoid.sspoid.api.service.auth.AuthService;
+import org.sspoid.sspoid.api.service.auth.EmailService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+    private final EmailService emailService;
+
+    @PostMapping("/sign-up")
+    public ResponseEntity<?> signUp(@Valid @RequestBody SignUpRequest request) {
+        try {
+            return ResponseEntity.status(HttpStatus.CREATED).body(authService.signUp(request));
+        }
+        catch (IllegalStateException e){
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
+        }
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.status(HttpStatus.OK).body(authService.login(request));
+    }
+
+    @PostMapping("/email/send") //메일 전송
+    public ResponseEntity<Void> sendEmail(@Valid @RequestBody EmailSendRequest request) {
+        emailService.sendCodeToEmail(request.email());
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/email/verify") //메일 인증
+    public ResponseEntity<String> verifyEmail(@Valid @RequestBody EmailVerifyRequest request) {
+        EmailService.VerificationResult result = emailService.verifyEmail(request.email(), request.code());
+
+        switch (result) {
+            case SUCCESS -> {
+                return ResponseEntity.ok("이메일 인증 성공!");
+            }
+            case BAD_REQUEST -> {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body("인증 코드가 발송되지 않았습니다.");
+            }
+            case UNAUTHORIZED -> {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                        .body("인증 코드가 일치하지 않습니다.");
+            }
+            case GONE -> {
+                return ResponseEntity.status(HttpStatus.GONE)
+                        .body("인증 코드가 만료되었습니다.");
+            }
+        }
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).
+                body("알 수 없는 오류가 발생하였습니다: " + result.toString());
+    }
+}

--- a/src/main/java/org/sspoid/sspoid/api/controller/auth/KakaoLoginController.java
+++ b/src/main/java/org/sspoid/sspoid/api/controller/auth/KakaoLoginController.java
@@ -18,7 +18,7 @@ public class KakaoLoginController {
 
     private final KakaoLoginService kakaoLoginService;
 
-    @PostMapping("/api/login/kakao")
+    @PostMapping("/api/auth/login/kakao")
     public ResponseEntity<?> callback(@Valid @RequestBody KakaoLoginRequest request) {
         String accessToken = kakaoLoginService.getAccessToken(request.code());
         KakaoUserInfoResponse userInfo = kakaoLoginService.getUserInfo(accessToken);

--- a/src/main/java/org/sspoid/sspoid/api/controller/auth/KakaoLoginController.java
+++ b/src/main/java/org/sspoid/sspoid/api/controller/auth/KakaoLoginController.java
@@ -1,12 +1,13 @@
 package org.sspoid.sspoid.api.controller.auth;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.sspoid.sspoid.api.dto.KakaoLoginRequest;
 import org.sspoid.sspoid.api.dto.KakaoUserInfoResponse;
 import org.sspoid.sspoid.api.service.KakaoLoginService;
 
@@ -17,9 +18,9 @@ public class KakaoLoginController {
 
     private final KakaoLoginService kakaoLoginService;
 
-    @GetMapping("/api/login/kakao")
-    public ResponseEntity<?> callback(@RequestParam("code") String code) {
-        String accessToken = kakaoLoginService.getAccessToken(code);
+    @PostMapping("/api/login/kakao")
+    public ResponseEntity<?> callback(@Valid @RequestBody KakaoLoginRequest request) {
+        String accessToken = kakaoLoginService.getAccessToken(request.code());
         KakaoUserInfoResponse userInfo = kakaoLoginService.getUserInfo(accessToken);
 
         return ResponseEntity.ok(userInfo);

--- a/src/main/java/org/sspoid/sspoid/api/dto/KakaoLoginRequest.java
+++ b/src/main/java/org/sspoid/sspoid/api/dto/KakaoLoginRequest.java
@@ -1,0 +1,9 @@
+package org.sspoid.sspoid.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record KakaoLoginRequest (
+        @NotBlank(message = "Authorization Code는 필수 입력 항목입니다.")
+        String code
+){
+}

--- a/src/main/java/org/sspoid/sspoid/api/dto/auth/EmailSendRequest.java
+++ b/src/main/java/org/sspoid/sspoid/api/dto/auth/EmailSendRequest.java
@@ -1,0 +1,11 @@
+package org.sspoid.sspoid.api.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailSendRequest (
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+        String email
+){
+}

--- a/src/main/java/org/sspoid/sspoid/api/dto/auth/EmailVerifyRequest.java
+++ b/src/main/java/org/sspoid/sspoid/api/dto/auth/EmailVerifyRequest.java
@@ -1,0 +1,14 @@
+package org.sspoid.sspoid.api.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailVerifyRequest (
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+        String email,
+
+        @NotBlank(message = "인증 코드는 필수 입력 항목입니다.")
+        String code
+){
+}

--- a/src/main/java/org/sspoid/sspoid/api/dto/auth/LoginRequest.java
+++ b/src/main/java/org/sspoid/sspoid/api/dto/auth/LoginRequest.java
@@ -1,0 +1,14 @@
+package org.sspoid.sspoid.api.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+        String password
+){
+}

--- a/src/main/java/org/sspoid/sspoid/api/dto/auth/SignUpRequest.java
+++ b/src/main/java/org/sspoid/sspoid/api/dto/auth/SignUpRequest.java
@@ -1,0 +1,17 @@
+package org.sspoid.sspoid.api.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record SignUpRequest (
+        @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
+        String nickname,
+
+        @Email
+        @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호은 필수 입력 항목입니다.")
+        String password
+){
+}

--- a/src/main/java/org/sspoid/sspoid/api/dto/auth/TokenResponse.java
+++ b/src/main/java/org/sspoid/sspoid/api/dto/auth/TokenResponse.java
@@ -1,0 +1,10 @@
+package org.sspoid.sspoid.api.dto.auth;
+
+import lombok.Builder;
+
+@Builder
+public record TokenResponse (
+        String accessToken,
+        String refreshToken
+){
+}

--- a/src/main/java/org/sspoid/sspoid/api/dto/auth/VerificationCode.java
+++ b/src/main/java/org/sspoid/sspoid/api/dto/auth/VerificationCode.java
@@ -1,0 +1,20 @@
+package org.sspoid.sspoid.api.dto.auth;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class VerificationCode {
+
+    private String code;
+
+    private LocalDateTime expiresTime;
+}

--- a/src/main/java/org/sspoid/sspoid/api/service/auth/AuthService.java
+++ b/src/main/java/org/sspoid/sspoid/api/service/auth/AuthService.java
@@ -1,0 +1,99 @@
+package org.sspoid.sspoid.api.service.auth;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.sspoid.sspoid.api.dto.auth.LoginRequest;
+import org.sspoid.sspoid.api.dto.auth.SignUpRequest;
+import org.sspoid.sspoid.api.dto.auth.TokenResponse;
+import org.sspoid.sspoid.common.security.JwtTokenProvider;
+import org.sspoid.sspoid.db.token.RefreshToken;
+import org.sspoid.sspoid.db.token.RefreshTokenRepository;
+import org.sspoid.sspoid.db.user.User;
+import org.sspoid.sspoid.db.user.UserRepository;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final JwtTokenProvider jwtUtil;
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+
+    @Transactional
+    public TokenResponse signUp(SignUpRequest request) {
+
+        if (userRepository.existsByEmail(request.email())) {
+            throw new IllegalStateException("이미 존재하는 이메일입니다");
+        }
+        User newUser = User.builder()
+                .name(request.nickname())
+                .password(passwordEncoder.encode(request.password()))
+                .email(request.email())
+                .build();
+
+        userRepository.save(newUser);
+
+        String accessToken = jwtUtil.createAccessToken(newUser);
+        String refreshToken = jwtUtil.createRefreshToken(newUser);
+
+        saveRefreshToken(newUser, refreshToken);
+
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    @Transactional
+    public TokenResponse login(LoginRequest request) {
+
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            log.warn("[LOGIN FAILED] email={}, timestamp={}", user.getEmail(), LocalDateTime.now());
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        RefreshToken refreshTokenEntity = refreshTokenRepository.findByUserId(user.getId())
+                .orElseThrow(()-> new IllegalArgumentException("토큰이 존재하지 않습니다,"));
+
+        String accessToken = "";
+        String refreshToken = refreshTokenEntity.getToken();
+
+        if (jwtUtil.isValidRefreshToken(refreshToken)) { //refreshtoken 유효성 검증 갱신
+            accessToken = jwtUtil.createAccessToken(user);
+            return TokenResponse.builder()
+                    .accessToken(accessToken)
+                    .refreshToken(refreshToken)
+                    .build();
+        }
+
+        refreshToken = jwtUtil.createRefreshToken(user);
+        refreshTokenEntity.updateToken(refreshToken);
+
+        return TokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    private void saveRefreshToken(User newUser, String refreshToken) {
+        RefreshToken token = RefreshToken.builder()
+                        .user(newUser)
+                        .token(refreshToken)
+                        .build();
+        refreshTokenRepository.save(token);
+    }
+
+}

--- a/src/main/java/org/sspoid/sspoid/api/service/auth/EmailService.java
+++ b/src/main/java/org/sspoid/sspoid/api/service/auth/EmailService.java
@@ -1,0 +1,84 @@
+package org.sspoid.sspoid.api.service.auth;
+
+import jakarta.mail.MessagingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.sspoid.sspoid.api.dto.auth.VerificationCode;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final EmailUtil emailUtil;
+
+    private static final String RANDOM_CODE_CHARACTERS = "ABCDEFGHJKLMNPQRSTUVWXYZ" +
+            "abcdefghijkmnpqrstuvwxyz" +
+            "123456789";
+
+    private final Map<String, VerificationCode> codeMap = new ConcurrentHashMap<>();
+
+    public void sendCodeToEmail(String email) { //이메일 전송
+        String code = generateRandomCode(6);
+        LocalDateTime expireTime = LocalDateTime.now().plusMinutes(10);
+
+        codeMap.put(email, new VerificationCode(code, expireTime));
+
+        String title = "[SSPOID] 이메일 인증";
+        String content = "<html>"
+                + "<body>"
+                + "<h2>SSPOID 인증 코드</h2>"
+                + "<h1>" + code + "</h1>"
+                + "<p>인증코드는 10분 동안 유효합니다.</p>"
+                + "</body>"
+                + "</html>";
+        try {
+            emailUtil.sendMail(email, title, content);
+        } catch (MessagingException e){
+            throw new RuntimeException("Unable to send email", e);
+        }
+    }
+
+    public String generateRandomCode(int length){ //랜덤코드 생성
+        StringBuilder randomCode = new StringBuilder();
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+
+        for(int i = 0; i < length; i++){
+            int index = random.nextInt(RANDOM_CODE_CHARACTERS.length());
+            randomCode.append(RANDOM_CODE_CHARACTERS.charAt(index));
+        }
+        return randomCode.toString();
+    }
+
+    public VerificationResult verifyEmail(String email, String code) {
+        VerificationCode stored = codeMap.get(email);
+
+        if (stored == null) {
+            return VerificationResult.BAD_REQUEST;
+        }
+
+        if (!stored.getCode().equals(code)) {
+            return VerificationResult.UNAUTHORIZED;
+        }
+
+        if (stored.getExpiresTime().isBefore(LocalDateTime.now())) {
+            return VerificationResult.GONE;
+        }
+
+        codeMap.remove(email); //인증 성공 시 제거
+        return VerificationResult.SUCCESS;
+    }
+
+    public enum VerificationResult {
+        SUCCESS,
+        BAD_REQUEST,
+        UNAUTHORIZED,
+        GONE
+    }
+}

--- a/src/main/java/org/sspoid/sspoid/api/service/auth/EmailUtil.java
+++ b/src/main/java/org/sspoid/sspoid/api/service/auth/EmailUtil.java
@@ -1,0 +1,36 @@
+package org.sspoid.sspoid.api.service.auth;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmailUtil {
+
+    private final JavaMailSender emailSender;
+
+    public void sendMail(String to, String title, String content) throws MessagingException {
+        MimeMessage message = emailSender.createMimeMessage();
+
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(message, true);
+
+            helper.setTo(to);
+            helper.setSubject(title);
+            helper.setText(content, true);
+            helper.setReplyTo("sspoid21@gmail.com");
+
+            emailSender.send(message);
+            log.info("✅ 이메일 발송 성공 - 대상: {}", to);
+        } catch (RuntimeException e) {
+            log.error("❌ 이메일 발송 실패 - 대상: {}", to, e);
+            throw new RuntimeException("Unable to send email", e);
+        }
+    }
+}

--- a/src/main/java/org/sspoid/sspoid/common/config/EmailConfig.java
+++ b/src/main/java/org/sspoid/sspoid/common/config/EmailConfig.java
@@ -1,0 +1,62 @@
+package org.sspoid.sspoid.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.sspoid.sspoid.api.service.auth.EmailUtil;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttls;
+
+    @Bean
+    public EmailUtil mailService() {
+        return new EmailUtil(javaMailSender());
+    }
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties mailProperties = new Properties();
+        mailProperties.put("mail.smtp.auth", auth);
+        mailProperties.put("mail.smtp.timeout", timeout);
+        mailProperties.put("mail.smtp.starttls.enable", starttls);
+
+        return mailProperties;
+    }
+}

--- a/src/main/java/org/sspoid/sspoid/common/security/JwtTokenProvider.java
+++ b/src/main/java/org/sspoid/sspoid/common/security/JwtTokenProvider.java
@@ -1,0 +1,66 @@
+package org.sspoid.sspoid.common.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.sspoid.sspoid.db.user.User;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.access-token-expiration}")
+    private Long accessTokenExpiration;
+    @Value("${jwt.refresh-token-expiration}")
+    private Long refreshTokenExpiration;
+
+    private final SecretKey secretKey;
+
+    private static final String JWT_CLAIMS = "email";
+
+    public JwtTokenProvider(@Value("${jwt.secret}") String secret) {
+        this.secretKey = new SecretKeySpec(
+                secret.getBytes(StandardCharsets.UTF_8),
+                "HmacSHA256");
+    }
+
+    public String createAccessToken(User user) {
+        return Jwts.builder()
+                .claim(JWT_CLAIMS, user.getEmail())
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + accessTokenExpiration))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String createRefreshToken(User user) {
+        return Jwts.builder()
+                .claim(JWT_CLAIMS, user.getEmail())
+                .expiration(new Date(System.currentTimeMillis() + refreshTokenExpiration))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public boolean isValidRefreshToken(String refreshToken) {
+        try {
+            getClaimsToken(refreshToken);
+            return true;
+        } catch (NullPointerException | JwtException e) {
+            return false;
+        }
+    }
+
+    public Claims getClaimsToken(String refreshToken) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(refreshToken)
+                .getPayload();
+    }
+}

--- a/src/main/java/org/sspoid/sspoid/db/chatmassage/ChatMessage.java
+++ b/src/main/java/org/sspoid/sspoid/db/chatmassage/ChatMessage.java
@@ -37,7 +37,7 @@ public class ChatMessage extends BaseEntity {
     @Column(name = "chat_session_id", nullable = false)
     private Long chatSessionId;
 
-    @Column
+    @Column(length = 10)
     @Enumerated(EnumType.STRING)
     private SenderType sender;
 

--- a/src/main/java/org/sspoid/sspoid/db/token/RefreshToken.java
+++ b/src/main/java/org/sspoid/sspoid/db/token/RefreshToken.java
@@ -1,0 +1,37 @@
+package org.sspoid.sspoid.db.token;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String token;
+
+    @OneToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "user_id")
+    private org.sspoid.sspoid.db.user.User user;
+
+    public void updateToken(String token) {
+        this.token = token;
+    }
+
+}

--- a/src/main/java/org/sspoid/sspoid/db/token/RefreshTokenRepository.java
+++ b/src/main/java/org/sspoid/sspoid/db/token/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package org.sspoid.sspoid.db.token;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByUserId(Long userId);
+}

--- a/src/main/java/org/sspoid/sspoid/db/user/UserRepository.java
+++ b/src/main/java/org/sspoid/sspoid/db/user/UserRepository.java
@@ -1,6 +1,13 @@
 package org.sspoid.sspoid.db.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -25,3 +25,7 @@ springdoc:
 #model:
 #  api:
 #    url: http://localhost:5000/api/generate //??
+
+logging:
+  level:
+    com.zaxxer.hikari: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,24 @@ server:
 spring:
   profiles:
     active: prod
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: sspoid21@gmail.com
+    password: ${PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          timeout: 5000
+          starttls:
+            enable: true
 
 kakao:
   api-key: ${API_KEY} # 암호화 필요
   redirect-uri: http://localhost:8080/api/login/kakao
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expiration: 3600000       # 1시간 (밀리초 단위)
+  refresh-token-expiration: 1209600000   # 14일 (밀리초 단위)


### PR DESCRIPTION
<!--
[제목]
작업: 회원 가입 기능 구현
-->
## 🔗 관련 이슈
<!--
ex) - #12  
-->
- #23 

## 📌 작업 내용
<!--
- 어떤 작업을 했는지 간단히 요약해주세요
- 예: 로그인 기능 API 연동
-->
### **[전체 구조]**
- JWT (Json Web Token) 기반 인증을 사용하여 로그인/회원가입 시 토큰 발급
- Access Token + Refresh Token 구조로 인증 유지
- 이메일 인증을 통해 사용자 유효성 검증
- 인증코드는 **서버 메모리(Map)**에 저장되며, 유효기간은 10분


### **[기능 설명]**
**1) 회원가입**
- 이메일 중복 검사 -> 존재 시 400 반환
- JwtTokenProvider를 통해 AccessToken, RefreshToken 생성 -> AccessToken은 클라이언트에 반환, RefreshToken은 DB에 저장
로그인

**2) 이메일 존재 여부 + 비밀번호 일치여부 확인**
- db에서 RefreshToken 조회 -> 유효하면 새로운 AccessToken 발급 / 아니면 RefreshToken 갱신
이메일 인증
- 사용자 이메일 입력 -> 서버에서 랜덤 코드 생성 -> 만료시간을 ConcurrentHashMap(codeMap)에 저장 -> 받은 코드 인증 -> ConcurrentHashMap에서 검증 후 성공, 실패 여부 반환 (DB 사용 X)

## 📚 참고 자료
<!--  
- https://example.com/signup-api (회원 가입 API 설계서)  
- https://example.com/bcrypt (Spring Security BCryptPasswordEncoder 사용법)
-->  

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
