### PR TITLE
feat: 채팅 세션 인가 처리 및 JWT 기반 사용자 식별 적용

### DIFF
--- a/src/main/java/org/sspoid/sspoid/api/controller/ChatBotController.java
+++ b/src/main/java/org/sspoid/sspoid/api/controller/ChatBotController.java
@@ -15,6 +15,7 @@ import org.sspoid.sspoid.api.dto.ChatMessageRequest;
 import org.sspoid.sspoid.api.dto.ChatMessageResponse;
 import org.sspoid.sspoid.api.dto.ChatSummaryResponse;
 import org.sspoid.sspoid.api.service.ChatBotService;
+import org.sspoid.sspoid.common.resolver.CurrentUser;
 
 import java.nio.file.AccessDeniedException;
 import java.util.List;

--- a/src/main/java/org/sspoid/sspoid/api/controller/ChatBotController.java
+++ b/src/main/java/org/sspoid/sspoid/api/controller/ChatBotController.java
@@ -2,6 +2,7 @@ package org.sspoid.sspoid.api.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -62,11 +63,17 @@ public class ChatBotController {
         return emitter;
     }
 
-
     // 4. 특정 세션에 저장되어있는 메시지 리스트 조회
     @GetMapping("/api/chat/sessions/{id}/messages")
-    public ResponseEntity<List<ChatMessageResponse>> getMessage(@PathVariable Long id) {
-        return ResponseEntity.ok(chatBotService.getMessagesBySessionId(id));
+    public ResponseEntity<List<ChatMessageResponse>> getMessage(
+            @PathVariable Long id,
+            @CurrentUser Long currentUserId
+    ) {
+        try {
+            return ResponseEntity.ok(chatBotService.getMessagesBySessionId(id, currentUserId));
+        } catch (AccessDeniedException e) {
+            return ResponseEntity.status(403).build();
+        }
     }
 
     // 5. 대화 요약
@@ -77,7 +84,7 @@ public class ChatBotController {
         try {
             return ResponseEntity.ok(chatBotService.getSummary(id, currentUserId));
         } catch (AccessDeniedException e) {
-                return ResponseEntity.status(403).build();
+            return ResponseEntity.status(403).build();
         }
     }
 }

--- a/src/main/java/org/sspoid/sspoid/api/controller/ChatBotController.java
+++ b/src/main/java/org/sspoid/sspoid/api/controller/ChatBotController.java
@@ -5,9 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,16 +13,14 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter;
 import org.sspoid.sspoid.api.dto.ChatMessageRequest;
 import org.sspoid.sspoid.api.dto.ChatMessageResponse;
-import org.sspoid.sspoid.api.dto.ChatSessionResponse;
 import org.sspoid.sspoid.api.dto.ChatSummaryResponse;
 import org.sspoid.sspoid.api.service.ChatBotService;
-import org.sspoid.sspoid.db.chatmassage.ChatMessage;
 
 import java.nio.file.AccessDeniedException;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Executors;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class ChatBotController {
@@ -72,6 +68,7 @@ public class ChatBotController {
         try {
             return ResponseEntity.ok(chatBotService.getMessagesBySessionId(id, currentUserId));
         } catch (AccessDeniedException e) {
+            log.warn("🚓 인가 실패: {}", e.getMessage());
             return ResponseEntity.status(403).build();
         }
     }
@@ -84,6 +81,7 @@ public class ChatBotController {
         try {
             return ResponseEntity.ok(chatBotService.getSummary(id, currentUserId));
         } catch (AccessDeniedException e) {
+            log.warn("🚓 인가 실패: {}", e.getMessage());
             return ResponseEntity.status(403).build();
         }
     }

--- a/src/main/java/org/sspoid/sspoid/api/controller/CurrentUser.java
+++ b/src/main/java/org/sspoid/sspoid/api/controller/CurrentUser.java
@@ -1,0 +1,11 @@
+package org.sspoid.sspoid.api.controller;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser {
+}

--- a/src/main/java/org/sspoid/sspoid/api/controller/SessionController.java
+++ b/src/main/java/org/sspoid/sspoid/api/controller/SessionController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.sspoid.sspoid.api.dto.ChatSessionResponse;
 import org.sspoid.sspoid.api.service.ChatBotService;
 
+import java.nio.file.AccessDeniedException;
 import java.util.List;
 import java.util.Map;
 
@@ -23,24 +24,28 @@ public class SessionController {
 
     // 1. 세션 생성
     @PostMapping("/api/chat/sessions")
-    public ResponseEntity<ChatSessionResponse> createSessions() {
-        return ResponseEntity.ok(chatBotService.createSession());
+    public ResponseEntity<ChatSessionResponse> createSessions(@CurrentUser Long currentUserId) {
+        return ResponseEntity.ok(chatBotService.createSession(currentUserId));
     }
 
     //2. 세션 제목 수정
     @PatchMapping("/api/chat/sessions/{id}/title")
     public ResponseEntity<ChatSessionResponse> updateSessionTitle(
             @PathVariable Long id,
-            @RequestBody Map<String, String> request
-    ) {
+            @RequestBody Map<String, String> request,
+            @CurrentUser Long currentUserId
+    ) throws AccessDeniedException {
         String newTitle = request.get("title");
-        return ResponseEntity.ok(chatBotService.updateTitle(id, newTitle));
+        return ResponseEntity.ok(chatBotService.updateTitle(id, newTitle, currentUserId));
     }
 
     //세션 삭제
     @DeleteMapping("/api/chat/sessions/{id}")
-    public ResponseEntity<Void> deleteSession(@PathVariable Long id) {
-        chatBotService.deleteSession(id);
+    public ResponseEntity<Void> deleteSession(
+            @PathVariable Long id,
+            @CurrentUser Long currentUserId
+    ) throws AccessDeniedException {
+        chatBotService.deleteSession(id, currentUserId);
         return ResponseEntity.ok().build();
     }
 
@@ -49,5 +54,4 @@ public class SessionController {
     public ResponseEntity<List<ChatSessionResponse>> getSessions() {
         return ResponseEntity.ok(chatBotService.getSessions());
     }
-
 }

--- a/src/main/java/org/sspoid/sspoid/api/controller/SessionController.java
+++ b/src/main/java/org/sspoid/sspoid/api/controller/SessionController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.sspoid.sspoid.api.dto.ChatSessionResponse;
 import org.sspoid.sspoid.api.service.ChatBotService;
+import org.sspoid.sspoid.common.resolver.CurrentUser;
 
 import java.nio.file.AccessDeniedException;
 import java.util.List;

--- a/src/main/java/org/sspoid/sspoid/api/controller/auth/AuthController.java
+++ b/src/main/java/org/sspoid/sspoid/api/controller/auth/AuthController.java
@@ -4,10 +4,12 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.sspoid.sspoid.api.controller.CurrentUser;
 import org.sspoid.sspoid.api.dto.auth.EmailSendRequest;
 import org.sspoid.sspoid.api.dto.auth.EmailVerifyRequest;
 import org.sspoid.sspoid.api.dto.auth.LoginRequest;
@@ -68,5 +70,10 @@ public class AuthController {
         }
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).
                 body("알 수 없는 오류가 발생하였습니다: " + result.toString());
+    }
+
+    @GetMapping("/test/user")
+    public ResponseEntity<String> testCurrentUser(@CurrentUser Long currentUserId) {
+        return ResponseEntity.ok("현재 유저 ID: " + currentUserId);
     }
 }

--- a/src/main/java/org/sspoid/sspoid/api/controller/auth/AuthController.java
+++ b/src/main/java/org/sspoid/sspoid/api/controller/auth/AuthController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.sspoid.sspoid.api.controller.CurrentUser;
+import org.sspoid.sspoid.common.resolver.CurrentUser;
 import org.sspoid.sspoid.api.dto.auth.EmailSendRequest;
 import org.sspoid.sspoid.api.dto.auth.EmailVerifyRequest;
 import org.sspoid.sspoid.api.dto.auth.LoginRequest;

--- a/src/main/java/org/sspoid/sspoid/api/service/ChatBotService.java
+++ b/src/main/java/org/sspoid/sspoid/api/service/ChatBotService.java
@@ -90,6 +90,10 @@ public class ChatBotService {
     @Transactional
     public List<ChatMessageResponse> sendMessage(Long id, ChatMessageRequest request) {
 
+        ChatSession session = chatSessionRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Session not found"));
+
+
         List<SkinGroup> skinGroups = (request.skinTypes() == null || request.skinTypes().isEmpty())
                 ? DEFAULT_SKIN_TYPES : request.skinTypes();
 
@@ -101,7 +105,7 @@ public class ChatBotService {
 
         //1. 메세지 전송
         ChatMessage userMessage = ChatMessage.builder()
-                .chatSessionId(id)
+                .chatSession(session)
                 .sender(SenderType.USER)
                 .skinTypes(skinTypes)
                 .message(request.message())
@@ -119,7 +123,7 @@ public class ChatBotService {
 
             // BOT 메시지 저장 - skinType은 단일로만 저장
             ChatMessage aiMessage = ChatMessage.builder()
-                    .chatSessionId(id)
+                    .chatSession(session)
                     .sender(SenderType.BOT)
                     .skinTypes(List.of(skinType)) // 단일 스킨타입만 저장
                     .message(aiResponse)

--- a/src/main/java/org/sspoid/sspoid/api/service/ChatBotService.java
+++ b/src/main/java/org/sspoid/sspoid/api/service/ChatBotService.java
@@ -112,7 +112,6 @@ public class ChatBotService {
 
         ChatSession session = chatSessionRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Session not found"));
-
         if (!session.getUser().getId().equals(currentUserId)) {
             throw new AccessDeniedException("해당 세션에 대한 권한이 없습니다.");
         }
@@ -168,7 +167,14 @@ public class ChatBotService {
     }
 
     // 5. 특정 세션에 저장되어있는 메시지 리스트 조회
-    public List<ChatMessageResponse> getMessagesBySessionId(Long id) {
+    public List<ChatMessageResponse> getMessagesBySessionId(Long id, Long currentUserId) throws AccessDeniedException {
+
+        ChatSession session = chatSessionRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Session not found"));
+        if (!session.getUser().getId().equals(currentUserId)) {
+            throw new AccessDeniedException("해당 세션에 대한 권한이 없습니다.");
+        }
+
         List<ChatMessage> messages = chatMessageRepository.findByChatSessionId(id);
 
         log.info("세션 메시지 조회 완료 - Session ID: {}, 메시지 수: {}", id, messages.size());

--- a/src/main/java/org/sspoid/sspoid/api/service/ChatBotService.java
+++ b/src/main/java/org/sspoid/sspoid/api/service/ChatBotService.java
@@ -17,7 +17,10 @@ import org.sspoid.sspoid.db.chatsession.ChatSession;
 import org.sspoid.sspoid.db.chatsession.ChatSessionRepository;
 import org.sspoid.sspoid.db.chatsession.SkinGroup;
 import org.sspoid.sspoid.db.chatsession.SkinType;
+import org.sspoid.sspoid.db.user.User;
+import org.sspoid.sspoid.db.user.UserRepository;
 
+import java.nio.file.AccessDeniedException;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -34,18 +37,24 @@ public class ChatBotService {
 
     private final ChatSessionRepository chatSessionRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final UserRepository userRepository;
 
     private final ChatPromptBuilder promptBuilder;
     private final CallApiService callApiService;
 
     // 1. 세션 생성
     @Transactional
-    public ChatSessionResponse createSession() {
+    public ChatSessionResponse createSession(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
         ChatSession chatSession = ChatSession.builder()
+                .user(user)
                 .title(DEFAULT_SESSION_TITLE)
                 .isBookmark(false)
                 .build();
         chatSessionRepository.save(chatSession);
+
         log.info("새로운 세션 생성 완료 - Session ID: {}", chatSession.getId());
         return ChatSessionResponse.from(chatSession);
 
@@ -53,12 +62,18 @@ public class ChatBotService {
 
     // 2. 세션 제목 수정
     @Transactional
-    public ChatSessionResponse updateTitle(Long id, String newTitle) {
+    public ChatSessionResponse updateTitle(Long id, String newTitle, Long currentUserId) throws AccessDeniedException {
+
         ChatSession session = chatSessionRepository.findById(id)
                 .orElseThrow(() -> {
                     log.error("세션 제목 수정 실패 - 존재하지 않는 Session ID: {}", id);
                     return new RuntimeException("Session not found");
                 });
+
+        if (!session.getUser().getId().equals(currentUserId)) {
+            throw new AccessDeniedException("해당 세션에 대한 권한이 없습니다.");
+        }
+
         session.updateTitle(newTitle);
 
         log.info("세션 제목 수정 완료 - Session ID: {}, New Title: {}", id, newTitle);
@@ -66,12 +81,17 @@ public class ChatBotService {
     }
 
     @Transactional
-    public void deleteSession(Long id) {
+    public void deleteSession(Long id, Long currentUserId) throws AccessDeniedException {
         ChatSession session = chatSessionRepository.findById(id)
                 .orElseThrow(() -> {
                     log.error("세션 삭제 실패 - 존재하지 않는 Session ID: {}", id);
                     return new RuntimeException("Session not found");
                 });
+
+        if (!session.getUser().getId().equals(currentUserId)) {
+            throw new AccessDeniedException("해당 세션에 대한 권한이 없습니다.");
+        }
+
         chatSessionRepository.delete(session);
         log.info("세션 삭제 완료 - Session ID: {}", id);
     }
@@ -88,11 +108,14 @@ public class ChatBotService {
 
     // 4. 메시지 전송 (유저 메시지 + 챗봇 응답 저장)
     @Transactional
-    public List<ChatMessageResponse> sendMessage(Long id, ChatMessageRequest request) {
+    public List<ChatMessageResponse> sendMessage(Long id, ChatMessageRequest request, Long currentUserId) throws AccessDeniedException {
 
         ChatSession session = chatSessionRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Session not found"));
 
+        if (!session.getUser().getId().equals(currentUserId)) {
+            throw new AccessDeniedException("해당 세션에 대한 권한이 없습니다.");
+        }
 
         List<SkinGroup> skinGroups = (request.skinTypes() == null || request.skinTypes().isEmpty())
                 ? DEFAULT_SKIN_TYPES : request.skinTypes();
@@ -158,11 +181,15 @@ public class ChatBotService {
 
     // 6. 요약 생성
     @Transactional
-    public ChatSummaryResponse getSummary(Long sessionId) {
+    public ChatSummaryResponse getSummary(Long sessionId, Long currentUserId) throws AccessDeniedException {
         ChatSession session = chatSessionRepository.findById(sessionId)
                 .orElseThrow(() -> new IllegalArgumentException("Session not found"));
 
         log.info("올바른 세션 형식입니다! Session ID: {}", sessionId);
+
+        if (!session.getUser().getId().equals(currentUserId)) {
+            throw new AccessDeniedException("해당 세션에 대한 권한이 없습니다.");
+        }
 
         List<ChatMessage> messages = chatMessageRepository.findByChatSessionId(sessionId);
 

--- a/src/main/java/org/sspoid/sspoid/common/config/WebConfig.java
+++ b/src/main/java/org/sspoid/sspoid/common/config/WebConfig.java
@@ -1,11 +1,19 @@
 package org.sspoid.sspoid.common.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.sspoid.sspoid.common.resolver.CurrentUserArgumentResolver;
+
+import java.util.List;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final CurrentUserArgumentResolver currentUserArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -20,4 +28,8 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowCredentials(true);
     }
 
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserArgumentResolver);
+    }
 }

--- a/src/main/java/org/sspoid/sspoid/common/resolver/CurrentUser.java
+++ b/src/main/java/org/sspoid/sspoid/common/resolver/CurrentUser.java
@@ -1,4 +1,4 @@
-package org.sspoid.sspoid.api.controller;
+package org.sspoid.sspoid.common.resolver;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/org/sspoid/sspoid/common/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/org/sspoid/sspoid/common/resolver/CurrentUserArgumentResolver.java
@@ -1,0 +1,43 @@
+package org.sspoid.sspoid.common.resolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.sspoid.sspoid.api.controller.CurrentUser;
+import org.sspoid.sspoid.common.security.JwtTokenProvider;
+
+@Component
+@RequiredArgsConstructor
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUser.class)
+                && parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new RuntimeException("Authorization 헤더가 없습니다.");
+        }
+
+        String token = authHeader.substring(7); // "Bearer " 이후 부분
+        return jwtTokenProvider.getUserIdFromToken(token);
+    }
+}

--- a/src/main/java/org/sspoid/sspoid/common/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/org/sspoid/sspoid/common/resolver/CurrentUserArgumentResolver.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
-import org.sspoid.sspoid.api.controller.CurrentUser;
 import org.sspoid.sspoid.common.security.JwtTokenProvider;
 
 @Component

--- a/src/main/java/org/sspoid/sspoid/common/security/JwtTokenProvider.java
+++ b/src/main/java/org/sspoid/sspoid/common/security/JwtTokenProvider.java
@@ -3,9 +3,11 @@ package org.sspoid.sspoid.common.security;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.sspoid.sspoid.db.user.User;
+import org.sspoid.sspoid.db.user.UserRepository;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -22,12 +24,15 @@ public class JwtTokenProvider {
 
     private final SecretKey secretKey;
 
+    private final UserRepository userRepository;
+
     private static final String JWT_CLAIMS = "email";
 
-    public JwtTokenProvider(@Value("${jwt.secret}") String secret) {
+    public JwtTokenProvider(@Value("${jwt.secret}") String secret, UserRepository userRepository) {
         this.secretKey = new SecretKeySpec(
                 secret.getBytes(StandardCharsets.UTF_8),
                 "HmacSHA256");
+        this.userRepository = userRepository;
     }
 
     public String createAccessToken(User user) {
@@ -63,4 +68,12 @@ public class JwtTokenProvider {
                 .parseSignedClaims(refreshToken)
                 .getPayload();
     }
+
+    public Long getUserIdFromToken(String token) {
+        String email = getClaimsToken(token).get("email", String.class);
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+        return user.getId();
+    }
+
 }

--- a/src/main/java/org/sspoid/sspoid/db/chatmassage/ChatMessage.java
+++ b/src/main/java/org/sspoid/sspoid/db/chatmassage/ChatMessage.java
@@ -12,12 +12,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sspoid.sspoid.db.BaseEntity;
+import org.sspoid.sspoid.db.chatsession.ChatSession;
 import org.sspoid.sspoid.db.chatsession.SkinType;
 
 import java.util.List;
@@ -34,8 +36,9 @@ public class ChatMessage extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "chat_session_id", nullable = false)
-    private Long chatSessionId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_session_id", nullable = false)
+    private ChatSession chatSession;
 
     @Column(length = 50)
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
<!--
[제목]
작업: 회원 가입 기능 구현
-->
## 🔗 관련 이슈
<!--
ex) - #12  
-->
- #28 

## 📌 작업 내용
자세한 내용은 노션에 문서화 해두었습니다!

### ✅ 목적

* 특정 사용자가 자신이 생성한 채팅 세션만 조회/수정/삭제할 수 있도록 인가(Authorization) 처리
* JWT 토큰에서 userId를 추출해 서비스 레이어에서 세션 접근 권한 확인

---

### 🔧 구현 개요

#### 1. `@CurrentUser` 어노테이션 도입

* 컨트롤러 메서드에서 JWT로부터 추출된 userId를 직접 파라미터로 받을 수 있도록 커스텀 어노테이션 `@CurrentUser` 정의

```java
@Target(ElementType.PARAMETER)
@Retention(RetentionPolicy.RUNTIME)
public @interface CurrentUser {}
```

---

#### 2. `CurrentUserArgumentResolver` 구현

* JWT 토큰을 파싱해 userId를 추출
* 파라미터가 `@CurrentUser`와 `Long.class` 타입일 때 userId를 주입
* `Authorization: Bearer <JWT>` 형식의 헤더에서 토큰 추출

```java
String token = authHeader.substring(7); // Bearer 제거
return jwtTokenProvider.getUserIdFromToken(token);
```

---

#### 3. `WebConfig`에 ArgumentResolver 등록

* `addArgumentResolvers()` 오버라이딩
* `@Component`로 등록된 `CurrentUserArgumentResolver`를 WebMvcConfigurer에 명시적으로 추가

```java
@Override
public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
    resolvers.add(currentUserArgumentResolver);
}
```

---

#### 4. ChatBotService 인가 처리 추가 / 컨트롤러에서 `@CurrentUser` 적용

* 모든 서비스 메서드에서 `session.getUser().getId().equals(currentUserId)`를 비교하여 인가 여부 판단

```java
if (!session.getUser().getId().equals(currentUserId)) {
    throw new AccessDeniedException("해당 세션에 대한 권한이 없습니다.");
}
```
* 기존에 존재했던 `private User user;` 필드를 실제 세션 생성 시 설정

```java
ChatSession chatSession = ChatSession.builder()
        .user(user)
        .title(DEFAULT_SESSION_TITLE)
        .isBookmark(false)
        .build();
```

---

### 🧪 테스트 결과 요약

* A 유저가 로그인 → 세션 생성 → 해당 세션 조회 요청 → ✅ 성공
* B 유저가 로그인 → A 유저의 세션 ID로 조회 요청 → ❌ 403 Forbidden 반환
* Postman을 통해 `Authorization: Bearer <AccessToken>` 헤더 설정으로 동작 확인


추가로 JWT 인증은 자체 구현이며 Spring Security는 사용하지 않았습니다!

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
